### PR TITLE
add buster debian OS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,15 @@ openmanage__repositories:
     state:         '{{ openmanage__deploy_state
                        if (ansible_distribution_release in ["stretch", "xenial"])
                        else "absent" }}'
+  # Version 910 - for OS Debian-Buster : Force using Stretch Repo as buster repo is not existing
+  - repo:          'deb http://linux.dell.com/repo/community/openmanage/910/stretch stretch main'
+    mode:          '0644'
+    filename:      'dell.openmanage'
+    key_id:        '1285491434D8786F'
+    key_keyserver: 'pool.sks-keyservers.net'
+    state:         '{{ openmanage__deploy_state
+                       if (ansible_distribution_release in ["buster"])
+                       else "absent" }}'
   # Previous version for Debian until Jessie and Ubuntu until Trusty
   - repo:          'deb http://linux.dell.com/repo/community/debian/dists/{{ ansible_distribution_release }} {{ ansible_distribution_release }} openmanage'
     mode:          '0644'
@@ -30,7 +39,7 @@ openmanage__repositories:
     key_id:        '1285491434D8786F'
     key_keyserver: 'pool.sks-keyservers.net'
     state:         '{{ openmanage__deploy_state
-                       if (ansible_distribution_release not in ["stretch", "xenial"])
+                       if (ansible_distribution_release not in ["buster","stretch", "xenial"])
                        else "absent" }}'
                                                                        # ]]]
                                                                    # ]]]

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
   - name: Debian
     versions:
     - stretch
+    - buster
   galaxy_tags:
     - system
     - openmanage

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,21 @@
   until: pkg_dep_result is success
   when: (openmanage__deploy_state == "present")
 
+- name: Dont install libssl1.0.0 on Buster
+  set_fact:
+    openmanage__base_packages:
+      - 'srvadmin-base'
+      - 'srvadmin-idracadm7'
+      - 'srvadmin-idracadm8'
+      - 'srvadmin-idrac-ivmcli'
+      - 'srvadmin-idrac-vmcli'
+      - 'srvadmin-omcommon'
+      - 'srvadmin-server-cli'
+      - 'srvadmin-server-snmp'
+      - 'srvadmin-storageservices'
+  when: (ansible_distribution_release == "buster")
+
+
 ## Manage base system packages
 - name: Ensure base packages are in there desired state
   package:
@@ -104,7 +119,7 @@
     src: "/usr/lib/x86_64-linux-gnu/libssl.so.1.0.2"
     path: "/opt/dell/srvadmin/lib64/libssl.so"
     state: link
-  when: (openmanage__deploy_state == "present")
+  when: (openmanage__deploy_state == "present" and ansible_distribution_release != "buster")
 
 ## Manage symlinks for OpenManage/racadm apps
 - name: Ensure some Executables are in PATH


### PR DESCRIPTION
Make the role working in OS buster :
- need to use the stretch repo as dell don't provide buster repo
- don't need anymore libssl1.0.0 (in buster it's installed by default libssl1.1 )
- don't need the trick of `Fix libssl error RAC1170` when using libssl1.1