### PR TITLE
fix #4

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,13 +82,19 @@
   notify: ['restart webgui service']
 
 ## Remove all OpenManage packages if requested
+- name: Gather the Package facts
+  package_facts:
+    manager: auto
+
 - name: Ensure to remove OpenManage related packages if requested
   package:
     name: 'srvadmin*'
     state: "absent"
   register: pkg_remove_result
   until: pkg_remove_result is success
-  when: (openmanage__deploy_state == "absent")
+  when:
+    - (openmanage__deploy_state == "absent")
+    - "'srvadmin' in ansible_facts.packages"
 
 # Executable [[[1
 ## Fix some permissions


### PR DESCRIPTION
Fix #4  :
- use package facts to known if the srvadmin is already install
- skip the task `Ensure to remove OpenManage related packages if requested` when it's not install